### PR TITLE
Reference "classic" comp repro papers

### DIFF
--- a/ro2019/limitations.tex
+++ b/ro2019/limitations.tex
@@ -7,9 +7,13 @@ Just as the overall scientific reproducibility of a study represented by a Resea
 	satisfy particular (namespaced) definitions of \emph{reproducible} or \emph{replicable},
 	additional statements could be made about the various dimensions of computational
 	reproducibility in particular.
-The aim would be for researchers publishing their work via ROs to be fully aware
-	of the implications of the claims they make about the computations represented
-	by the RO.
+
+There have long been discussions about packaging ROs for transparency and 
+    reproducibility \cite{claerbout1992, gentleman2007, peng2011}, but less emphasis has been
+    placed on \emph{describing} characteristics of the published ROs. The aim would be for researchers 
+    publishing their work via ROs to be fully aware of the implications of the claims they make about 
+    the computations represented by the RO.
+    
 Researchers discovering, evaluating, or using the Research Object for further research
 	 would be able to interpret these claims unambiguously.
 The implications for the possibilities of rerunning, reproducing, or exactly repeating the

--- a/ro2019/main.bib
+++ b/ro2019/main.bib
@@ -729,3 +729,102 @@ The workshop discussions included presentations of a number of the diverse and r
 }
 
 
+@article{christian2018,
+  title={Operationalizing the Replication Standard.},
+  author={Christian, Thu-Mai and Lafferty-Hess, Sophia and Jacoby, William G and Carsey, Thomas},
+  journal={IJDC},
+  volume={13},
+  number={1},
+  pages={114--124},
+  year={2018}
+}
+
+@article{gentleman2007,
+  title={Statistical analyses and reproducible research},
+  author={Gentleman, Robert and Temple Lang, Duncan},
+  journal={Journal of Computational and Graphical Statistics},
+  volume={16},
+  number={1},
+  pages={1--23},
+  year={2007},
+  publisher={Taylor \& Francis}
+}
+
+@incollection{claerbout1992,
+    Author = {Claerbout, Jon F and Karrenbach, Martin},
+    Booktitle = {SEG Technical Program Expanded Abstracts 1992},
+    Date-Added = {2018-01-14 15:30:18 +0000},
+    Date-Modified = {2018-01-14 15:31:52 +0000},
+    Doi = {10.1190/1.1822162},
+    Note = {\href{https://doi.org/10.1190/1.1822162}{doi:10.1190/1.1822162}},
+    Pages = {601--604},
+    Publisher = {Society of Exploration Geophysicists},
+    Title = {Electronic documents give reproducible research a new meaning},
+    Year = {1992},
+    Bdsk-Url-1 = {https://dx.doi.org/10.1190/1.1822162}
+} 
+
+
+@article{donoho2010,
+    author = {Donoho, David L.},
+    title = "{An invitation to reproducible computational research}",
+    journal = {Biostatistics},
+    volume = {11},
+    number = {3},
+    pages = {385-388},
+    year = {2010},
+    month = {07},
+    issn = {1465-4644},
+    doi = {10.1093/biostatistics/kxq028},
+    url = {https://doi.org/10.1093/biostatistics/kxq028}
+}
+
+@article{stodden2013a,
+   author = {Stodden, Victoria},
+   doi = {10.1109/mcse.2012.82},
+    issn = {1521-9615},
+    journal = {Computing in Science and Engineering},
+    keywords = {computational-science, reproducibility, reproducible-research},
+    pages = {11--12},
+    posted-at = {2012-09-12 13:54:06},
+    priority = {2},
+    publisher = {IEEE Computer Society},
+    title = {Reproducible research: tools and strategies for scientific computing},
+    url = {http://dx.doi.org/10.1109/mcse.2012.82},
+    volume = {14},
+    year = {2012}
+}
+
+@article{stodden2013b,
+    author = {Stodden, Victoria and Guo, Peixuan and Ma, Zhaokun},
+    day = {21},
+    doi = {10.1371/journal.pone.0067111},
+    issn = {1932-6203},
+    journal = {PLOS ONE},
+    keywords = {computational-science, data-sharing, free-scientific-software, journal-ranking, knowledge-freedom, open-data, publication-bias, reproducible-research, science-ethics, scientific-communication, scientific-knowledge-sharing},
+    month = jun,
+    number = {6},
+    pages = {e67111},
+    posted-at = {2013-08-29 17:02:08},
+    priority = {2},
+    publisher = {Public Library of Science},
+    title = {Toward reproducible computational research: an empirical analysis of data and code policy adoption by journals},
+    url = {http://dx.doi.org/10.1371/journal.pone.0067111},
+    volume = {8},
+    year = {2013}
+}
+
+@article{stodden2014a,
+    author = {Victoria Stodden and Sheila Miguez},
+    title = {Best Practices for Computational Science: Software Infrastructure and Environments for Reproducible and Extensible Research},
+    year = {2014},
+    volume = {2},
+    numer = {1},
+    doi = {http://doi.org/10.5334/jors.ay},
+    journal = {Journal of Open Research Software}
+}
+
+
+
+@article{peng2011, title={Reproducible Research in Computational Science}, volume={334}, ISSN={0036-8075, 1095-9203}, DOI={10.1126/science.1213847}, abstractNote={Computational science has led to exciting new developments, but the nature of the work has exposed limitations in our ability to evaluate published findings. Reproducibility has the potential to serve as a minimum standard for judging scientific claims when full independent replication of a study is not possible.}, number={6060}, journal={Science}, author={Peng, Roger D.}, year={2011}, month={Dec}, pages={1226–1227} }
+


### PR DESCRIPTION
Made minor changes to try to ground the limitations section in some of the existing papers on computational reproducibility. Added a section to tie to packaging discussion. 